### PR TITLE
:bug: fix mk-pages

### DIFF
--- a/bibyfi-IEEETran.satyh
+++ b/bibyfi-IEEETran.satyh
@@ -25,7 +25,7 @@ end = struct
 
   let mk-pages (s, e) =
     let it-s = embed-string s in
-    let it-e = embed-string s in
+    let it-e = embed-string e in
     {pp. #it-s;–#it-e;}
 
   let mk-year-month year month =


### PR DESCRIPTION
引用の頁番号(pp. x-y)のx, yがどちらも開始の頁になっていたため，修正しました